### PR TITLE
Feature/embeddings v1 mini lm

### DIFF
--- a/scripts/Embedding/embed_gl_accounts.py
+++ b/scripts/Embedding/embed_gl_accounts.py
@@ -1,0 +1,59 @@
+"""
+Script: embed_gl_directory.py
+Purpose: Generate embeddings for GL accounts using MiniLM
+Model: all-MiniLM-L6-v2
+Vector size: 768
+Date: 2025-09-25
+Author: Rulo
+"""
+
+import pandas as pd
+from sentence_transformers import SentenceTransformer
+import numpy as np
+import json
+
+# --- Load CSV ---
+df = pd.read_csv("data/clean/normalized_gl_accounts.csv")
+
+# --- Validate if required columns are present ---
+required_cols = {"normalized_name", "gl_code"}
+missing_cols = required_cols - set(df.columns)
+if missing_cols:
+    raise ValueError(f"Missing required columns: {missing_cols}")
+
+# Fill missing values
+df["normalized_name"] = df["normalized_name"].fillna("").astype(str).str.strip()
+df["gl_code"] = df["gl_code"].fillna("").astype(str).str.strip()
+
+# --- Load model ---
+model = SentenceTransformer("all-MiniLM-L6-v2")
+
+# --- Generate embeddings (you probably only want normalized_name) ---
+embeddings = model.encode(df["normalized_name"].tolist(), show_progress_bar=True)
+
+# --- Save as .npy ---
+np.save("data/embedded/gl_directory_embeddings.npy", embeddings)
+
+# --- Reload vectors ---
+vectors = np.load("data/embedded/gl_directory_embeddings.npy")
+
+# --- Build Qdrant points ---
+points = []
+for idx, row in df.iterrows():
+    payload = {
+        "normalized_name": row["normalized_name"],
+        "gl_code": row["gl_code"]
+    }
+    if "raw_name" in df.columns:
+        payload["raw_name"] = row["raw_name"]
+
+    point = {
+        "id": str(idx),
+        "vector": vectors[idx].tolist(),
+        "payload": payload
+    }
+    points.append(point)
+
+# --- Save as JSON for Qdrant (optional export) ---
+with open("data/embedded/gl_points.json", "w", encoding="utf-8") as f:
+    json.dump({"points": points}, f, ensure_ascii=False, indent=2)

--- a/scripts/Embedding/embed_property_directory.py
+++ b/scripts/Embedding/embed_property_directory.py
@@ -38,7 +38,7 @@ vectors = np.load("data/embedded/property_directory_embeddings.npy")
 points = []
 for idx, row in df.iterrows():
     point = {
-        "id": str(idx),  # puede ser un UUID si prefieres
+        "id": str(idx),  # Can be UUID or any unique identifier
         "vector": vectors[idx].tolist(),
         "payload": {
             "raw_property": row["raw_property"],

--- a/scripts/Embedding/embed_property_directory.py
+++ b/scripts/Embedding/embed_property_directory.py
@@ -1,0 +1,52 @@
+import pandas as pd
+from sentence_transformers import SentenceTransformer
+import numpy as np
+import pandas as pd
+import numpy as np
+import json
+
+# --- Load CSV ---
+df = pd.read_csv("data/clean/normalized_property_directory.csv")
+
+# --- Validate if column is present ---
+if "normalized_property" not in df.columns:
+    raise ValueError("The column 'normalized_property' doesn't exist.")
+
+# --- Preprocessing ---
+df["normalized_property"] = df["normalized_property"].fillna("").astype(str).str.strip()
+
+# --- Load model ---
+model = SentenceTransformer("all-MiniLM-L6-v2")  
+
+# --- Generate vectors ---
+embeddings = model.encode(df["normalized_property"].tolist(), show_progress_bar=True)
+
+# --- save as .npy ---
+np.save("data/embedded/property_directory_embeddings.npy", embeddings)
+
+# --- Opcional: save as CSV with IDs ---
+embedding_df = pd.DataFrame(embeddings)
+embedding_df["normalized_property"] = df["normalized_property"]
+embedding_df["raw_property"] = df["raw_property"]
+embedding_df.to_csv("data/embedded/property_directory_embeddings.csv", index=False)
+
+# --- Load data and vectors ---
+df = pd.read_csv("data/clean/normalized_property_directory.csv")
+vectors = np.load("data/embedded/property_directory_embeddings.npy")
+
+# Build Qdrant points
+points = []
+for idx, row in df.iterrows():
+    point = {
+        "id": str(idx),  # puede ser un UUID si prefieres
+        "vector": vectors[idx].tolist(),
+        "payload": {
+            "raw_property": row["raw_property"],
+            "normalized_property": row["normalized_property"]
+        }
+    }
+    points.append(point)
+
+# --- Save as JSON for Qdrant ---
+with open("data/embedded/property_points.json", "w", encoding="utf-8") as f:
+    json.dump({"points": points}, f, ensure_ascii=False, indent=2)

--- a/scripts/Embedding/embed_vendor_directory.py
+++ b/scripts/Embedding/embed_vendor_directory.py
@@ -1,0 +1,34 @@
+import pandas as pd
+import numpy as np
+import json
+from sentence_transformers import SentenceTransformer
+
+# --- Load and clean ---
+df = pd.read_csv("data/clean/normalized_vendor_directory.csv")
+df["normalized_company"] = df["normalized_company"].fillna("").astype(str).str.strip()
+
+# --- Load model ---
+model = SentenceTransformer("all-MiniLM-L6-v2")
+
+# --- Generate embeddings ---
+embeddings = model.encode(df["normalized_company"].tolist(), show_progress_bar=True)
+
+# --- Save vectors ---
+np.save("data/embedded/vendor_embeddings.npy", embeddings)
+
+# --- Build Qdrant points ---
+points = []
+for idx, row in df.iterrows():
+    payload = {
+        "normalized_company": row["normalized_company"],
+        "company_name": row.get("company_name", "")
+    }
+    points.append({
+        "id": str(idx),
+        "vector": embeddings[idx].tolist(),
+        "payload": payload
+    })
+
+# --- Export JSON ---
+with open("data/embedded/vendor_points.json", "w", encoding="utf-8") as f:
+    json.dump({"points": points}, f, ensure_ascii=False, indent=2)

--- a/scripts/Embedding/fuzzy_gate.py
+++ b/scripts/Embedding/fuzzy_gate.py
@@ -21,7 +21,7 @@ try:
     property_directory = pd.read_csv("data/clean/normalized_property_directory.csv")
     vendor_directory = pd.read_csv("data/clean/normalized_vendor_directory.csv")
 except FileNotFoundError as e:
-    print(f"❌ Error: {e}. Please ensure all input CSV files are in the 'data/clean/' directory.")
+    print(f"Error: {e}. Please ensure all input CSV files are in the 'data/clean/' directory.")
     sys.exit()
 
 # --- Helpers ---
@@ -146,12 +146,8 @@ def resolve_transaction_mappings(row):
     return "", "unresolved", 0.0, "", "", ""
 
 def resolve_cash_account(filename: str) -> str:
-    """
-    Determina el Cash Account según el nombre del archivo.
-      - Si contiene 'amex' → '1170: Amex'
-      - Si contiene 'mastercard' → '1180: AA Mastercard'
-      - Si no contiene ninguno → ''
-    """
+  # Determine the Cash Account based on the file name:
+
     fname = filename.lower()
     if "amex" in fname:
         return "1170: Amex"
@@ -226,5 +222,5 @@ new_df.loc[mask, "Bill Account*"] = "6435: General Repairs"
 # --- Save results to CSV---
 output_path = "data/clean/appfolio_ready_bulk.csv"
 new_df.to_csv(output_path, index=False, encoding="utf-8-sig")
-print(f"✅ File generated: {output_path}")
-print("   Remember to manually review 'unresolved' items or those with low confidence.")
+print(f"File generated: {output_path}")
+print("Remember to manually review 'unresolved' items or those with low confidence.")

--- a/scripts/ingestion/recreate_qdrant_collection.py
+++ b/scripts/ingestion/recreate_qdrant_collection.py
@@ -1,0 +1,16 @@
+from qdrant_client import QdrantClient
+from qdrant_client.models import VectorParams, Distance
+
+# Conexión local (ajusta si usas Qdrant Cloud)
+client = QdrantClient(host="localhost", port=6333)
+
+# Recrear colección con dimensión 768
+client.recreate_collection(
+    collection_name="rag_collection",
+    vectors_config=VectorParams(
+        size=768,
+        distance=Distance.COSINE  # Puedes usar EUCLID o DOT si prefieres
+    )
+)
+
+print("Colección 'rag_collection' recreada con dimensión 768.")

--- a/scripts/tests/test_embedding.py
+++ b/scripts/tests/test_embedding.py
@@ -1,0 +1,19 @@
+from sentence_transformers import SentenceTransformer
+from qdrant_client import QdrantClient
+from qdrant_client.models import SearchRequest
+
+model = SentenceTransformer("all-MiniLM-L6-v2")
+client = QdrantClient(host="localhost", port=6333)
+
+query = "11515 NW 22nd Avenue - BLDG 2 - 11515 NW 22nd Avenue Miami, FL 33167"
+vector = model.encode(query).tolist()
+
+results = client.search(
+    collection_name="rag_collection",
+    query_vector=vector,
+    limit=3,
+    with_payload=True
+)
+
+for r in results:
+    print(f"Score: {r.score:.3f} → {r.payload.get('normalized_property')}")


### PR DESCRIPTION
This PR introduces the embedding workflows for both the General Ledger (GL) accounts and Vendor directory using the model.
 Included in this update:
• 	GL Directory Embedding
• 	Source: 'normalized_gl_accounts.csv'
• 	Output: , `gl_points.json`, `vendor_points.json`
• 	Payload includes:  'gl_code', 'normalized_name', 'raw_name' ,  (if available)
• 	Vendor Directory Embedding
• 	Source: 'normalize_vendor_directory.csv
• 	Output: 'vendor_embeddings.npy', 'vendor_embeddings.json'
• 	Payload includes: 'normalized_company', 'company_name' 
 Model Details:
• 	Model: 'all-MiniLM-L6-v2'
• 	Vector dimension: 768
• 	Format: '.npy' for fast ingestion,  '.json'for Qdrant upsert
 Scripts Added:
• 	embed_vendor_directory
• 	embed_property_directory
•      embed_gl_accounts 

These scripts are modular, versioned, and ready for integration into the semantic retrieval pipeline.