### PR TITLE
Remove duplicates using Vendor Ledger as source of truth; any record …

### DIFF
--- a/scripts/ingestion/normalize_amex_statements.py
+++ b/scripts/ingestion/normalize_amex_statements.py
@@ -3,7 +3,6 @@ import sys
 import os
 import re
 import glob
-import datetime
 
 # ============================================================
 # 1. CONFIGURACIÓN DE ENTORNO
@@ -12,15 +11,12 @@ project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..
 if project_root not in sys.path:
     sys.path.insert(0, project_root)
 
-try:
-    from scripts.utils.text_cleaning import normalize_vendor as normalize
-except ImportError:
-    def normalize(text): return str(text).upper().strip()
-
 CANONICAL_COLUMNS = ['date', 'merchant', 'account_holder', 'column', 'amount', 'company', 'gl_account']
 
+RULES_FILE = "data/config/mapping_rules.xlsx"
+
 # ============================================================
-# 2. UTILIDADES DE LIMPIEZA
+# 2. UTILIDADES
 # ============================================================
 def clean_currency(series):
     return (
@@ -31,166 +27,137 @@ def clean_currency(series):
         ).fillna(0.0).round(2)
     )
 
-def clean_merchant(text: str) -> str:
-    if not text: return ""
+def clean_merchant(text):
+    if not text:
+        return ""
     t = str(text).upper()
     t = re.sub(r"\b\d{4,}\b", "", t)
     t = re.sub(r"[^\w\s]", " ", t)
     return re.sub(r"\s+", " ", t).strip()
 
 # ============================================================
-# 3. REGLAS DE NEGOCIO (RAS - ESTRICTO SIN RR)
+# 3. MAPPING RULES (FUENTE DE VERDAD)
 # ============================================================
-def apply_business_rules(df: pd.DataFrame) -> pd.DataFrame:
+def load_mapping_rules():
+    rules = (
+        pd.read_excel(RULES_FILE, sheet_name="merchant_rules")
+        .dropna(subset=["match_pattern"])
+        .sort_values("priority", ascending=False)
+    )
+    rules["match_pattern"] = rules["match_pattern"].str.lower()
+    return rules
+
+def apply_mapping_rules(merchant, rules_df):
+    m = str(merchant).lower()
+    for _, r in rules_df.iterrows():
+        if pd.Series(m).str.contains(r["match_pattern"], regex=True, na=False).iloc[0]:
+            return pd.Series({
+                "normalized_merchant": r["normalized_merchant"],
+                "vendor_class": r["vendor_class"]
+            })
+    return pd.Series({
+        "normalized_merchant": clean_merchant(merchant),
+        "vendor_class": "UNCLASSIFIED"
+    })
+
+# ============================================================
+# 4. REGLAS DE NEGOCIO RAS
+# ============================================================
+def apply_business_rules(df):
     def validate_row(row):
         acc = str(row.get('account_holder', '')).upper().strip()
         merc = str(row.get('merchant', '')).upper()
         comp = str(row.get('company', '')).upper()
         gl = str(row.get('gl_account', '')).upper()
 
-        status, notes = "KEEP", []
-
-        # 1. Identificación de Titulares (Respaldo en Merchant si Account está vacío)
-        is_armando = ("ARMANDO ARMAS" in acc) or (acc in ["", "NAN", "NONE"] and "ARMANDO ARMAS" in merc)
-        is_richard = ("RICHARD LIBUTTI" in acc) or (acc in ["", "NAN", "NONE"] and "RICHARD LIBUTTI" in merc)
-
-        # 2. Marcas Explícitas (SOLO RAS y REITER, excluyendo RR solo)
+        is_armando = "ARMANDO ARMAS" in acc or (acc in ["", "NAN"] and "ARMANDO ARMAS" in merc)
+        is_richard = "RICHARD LIBUTTI" in acc or (acc in ["", "NAN"] and "RICHARD LIBUTTI" in merc)
         is_ras_marked = any(x in comp or x in gl for x in ["RAS", "REITER"])
 
-        # EXCEPCIÓN
         if is_richard and "HAPPY TRAILERS" in comp:
-            return pd.Series(["EXCEPTION", "Richard Libutti no opera Happy Trailers"])
+            return pd.Series(["EXCEPTION", "Richard no opera Happy Trailers"])
 
-        # LÓGICA DE FILTRADO
         if is_ras_marked or is_armando or is_richard:
-            status = "KEEP"
-            if is_ras_marked: notes.append("Marca RAS/REITER detectada")
-            if acc in ["", "NAN", "NONE"] and (is_armando or is_richard): notes.append("Titular en Merchant")
-        else:
-            status = "SKIP"
-
-        return pd.Series([status, "; ".join(notes)])
+            return pd.Series(["KEEP", "RAS validado"])
+        return pd.Series(["SKIP", "No RAS"])
 
     df = df.copy()
-    df[['validation_status', 'business_notes']] = df.apply(validate_row, axis=1)
+    df[["validation_status", "business_notes"]] = df.apply(validate_row, axis=1)
     return df
 
 # ============================================================
-# 4. CARGA DE ARCHIVOS (CORREGIDO)
+# 5. CARGA AMEX
 # ============================================================
-def load_amex_file(filepath: str) -> pd.DataFrame:
+def load_amex_file(filepath):
     ext = filepath.lower().split('.')[-1]
-    
-    # Lectura inicial para inspección
     raw = pd.read_excel(filepath, header=None) if ext == "xlsx" else pd.read_csv(filepath, header=None)
 
     header_row = None
-
-    # Buscar encabezados reales (ej. "DATE", "AMOUNT")
     for i in range(min(15, len(raw))):
-        row_values = [str(val).upper() for val in raw.iloc[i].values]
-        row_text = " ".join(row_values)
-
-        if "DATE" in row_text and "AMOUNT" in row_text:
+        row = " ".join(str(v).upper() for v in raw.iloc[i].values)
+        if "DATE" in row and "AMOUNT" in row:
             header_row = i
             break
 
-    # -------------------------------
-    # CASO 1: ARCHIVO CON ENCABEZADOS
-    # -------------------------------
     if header_row is not None:
         df = pd.read_excel(filepath, header=header_row) if ext == "xlsx" else pd.read_csv(filepath, header=header_row)
-        df.columns = [str(c).strip().upper() for c in df.columns]
-
-    # ---------------------------------------------------------
-    # CASO 2: ARCHIVO SIN ENCABEZADOS (Tu caso actual)
-    # ---------------------------------------------------------
     else:
-        # IMPORTANTE: Re-leer con header=None para NO perder la primera fila de datos
-        df = pd.read_excel(filepath, header=None) if ext == "xlsx" else pd.read_csv(filepath, header=None)
-        
-        # Asignar nombres temporales para que el resto del script no falle
-        n_cols = df.shape[1]
-        temp_columns = CANONICAL_COLUMNS[:n_cols]
-        if n_cols > len(CANONICAL_COLUMNS):
-            temp_columns += [f"extra_{i}" for i in range(n_cols - len(CANONICAL_COLUMNS))]
-        
-        df.columns = temp_columns
+        df = raw.copy()
+        df.columns = CANONICAL_COLUMNS + [
+            f"extra_{i}" for i in range(df.shape[1] - len(CANONICAL_COLUMNS))
+        ]
 
-    # --- NORMALIZACIÓN FINAL DE COLUMNAS ---
-    if df.shape[1] < len(CANONICAL_COLUMNS):
-        raise ValueError(f"Columnas insuficientes en {os.path.basename(filepath)}")
-
-    # Aseguramos el orden canónico exacto
-    df.columns = CANONICAL_COLUMNS + [
-        f"extra_{i}" for i in range(df.shape[1] - len(CANONICAL_COLUMNS))
-    ]
-
+    df.columns = df.columns.str.lower()
     return df
 
-
 # ============================================================
-# 5. PIPELINE PRINCIPAL
+# 6. PIPELINE PRINCIPAL
 # ============================================================
 def main():
     INPUT_FOLDER = "data/raw/unify_all_amex/"
     OUTPUT_PATH = "data/clean/normalized_amex.csv"
-    
+
+    rules = load_mapping_rules()
+
     files = glob.glob(os.path.join(INPUT_FOLDER, "*.csv")) + glob.glob(os.path.join(INPUT_FOLDER, "*.xlsx"))
-
-    if not files:
-        print("❌ No se encontraron archivos.")
-        return
-
     dfs = []
+
     for f in files:
-        try:
-            df = load_amex_file(f)
-            df["source_file"] = os.path.basename(f)
-            dfs.append(df)
-        except Exception as e:
-            print(f"❌ Error en {f}: {e}")
+        df = load_amex_file(f)
+        df["source_file"] = os.path.basename(f)
+        dfs.append(df)
 
-    if not dfs:
-        return
-
-    df_raw = pd.concat(dfs, ignore_index=True)
-    df_raw['amount'] = clean_currency(df_raw['amount'])
+    amex = pd.concat(dfs, ignore_index=True)
+    amex["amount"] = clean_currency(amex["amount"])
 
     # Deduplicación
-    group_cols = ['date', 'merchant', 'account_holder', 'amount', 'company']
-    df_raw['occurrence'] = df_raw.groupby(group_cols).cumcount()
-    df_raw['dedup_key'] = (df_raw['date'].astype(str) + "|" + df_raw['amount'].astype(str) + "|" + 
-    df_raw['merchant'].str.upper().str.strip() + "|" + df_raw['occurrence'].astype(str))
-    
-    df_dedup = df_raw.drop_duplicates(subset='dedup_key', keep='first').copy()
-    statement_total = round(df_dedup['amount'].sum(), 2)
+    key_cols = ["date", "merchant", "amount"]
+    amex["occ"] = amex.groupby(key_cols).cumcount()
+    amex["dedup_key"] = (
+        amex["date"].astype(str) + "|" +
+        amex["merchant"].astype(str) + "|" +
+        amex["amount"].astype(str) + "|" +
+        amex["occ"].astype(str)
+    )
+    amex = amex.drop_duplicates("dedup_key")
 
-    df_final = apply_business_rules(df_dedup)
-    
-    processed_df = df_final[df_final['validation_status'] != "SKIP"].copy()
-    charges_only = round(processed_df[processed_df['amount'] > 0]['amount'].sum(), 2)
-    credits_only = round(processed_df[processed_df['amount'] < 0]['amount'].sum(), 2)
-    skipped_total = round(df_final[df_final['validation_status'] == "SKIP"]['amount'].sum(), 2)
-    diff = round(statement_total - (charges_only + credits_only + skipped_total), 2)
+    # Reglas RAS
+    amex = apply_business_rules(amex)
+    amex = amex[amex["validation_status"] != "SKIP"].copy()
 
-    
+    # 🔥 NORMALIZACIÓN CENTRALIZADA
+    mapped = amex["merchant"].apply(lambda x: apply_mapping_rules(x, rules))
+    amex["normalized_merchant"] = mapped["normalized_merchant"]
+    amex["vendor_class"] = mapped["vendor_class"]
 
-    print("\n" + "╔" + "═" * 62 + "╗")
-    print(f"║ {'REPORTE FINANCIERO RAS - AMEX (VERSIÓN FINAL)':^60} ║")
-    print("╠" + "═" * 62 + "╣")
-    print(f"║ {'VALOR REAL GASTOS RAS (Cargos):':<35} ${charges_only:>18,.2f} ║")
-    print(f"║ {'Abonos/Devoluciones Procesados:':<35} ${credits_only:>18,.2f} ║")
-    print(f"║ {'Pagos a Tarjeta (Omitidos):':<35} ${skipped_total:>18,.2f} ║")
-    print("╟" + "─" * 62 + "╢")
-    print(f"║ {'NETO BANCARIO (Statement Total):':<35} ${statement_total:>18,.2f} ║")
-    print("╠" + "═" * 62 + "╣")
-    print(f"║ {'✅ CONCILIACIÓN RAS EXITOSA':^60} ║" if abs(diff) <= 0.01 else f"║ {'🚨 DIFERENCIA: $' + str(diff):^60} ║")
-    print("╚" + "═" * 62 + "╝")
+    # Auditoría
+    unclassified = (amex["vendor_class"] == "UNCLASSIFIED").sum()
+    if unclassified:
+        print(f"⚠️ {unclassified} merchants sin clasificar (revisar mapping_rules.xlsx)")
 
-    processed_df['normalized_merchant'] = processed_df['merchant'].apply(clean_merchant).apply(normalize)
     os.makedirs(os.path.dirname(OUTPUT_PATH), exist_ok=True)
-    processed_df.to_csv(OUTPUT_PATH, index=False)
+    amex.to_csv(OUTPUT_PATH, index=False)
+    print(f"✅ Archivo generado: {OUTPUT_PATH}")
 
 if __name__ == "__main__":
     main()

--- a/scripts/reconciliation/dedup_ace_appfolio.py
+++ b/scripts/reconciliation/dedup_ace_appfolio.py
@@ -3,159 +3,199 @@ from datetime import timedelta
 import os
 
 # ============================================================
-# 1. CONFIGURACIÓN Y CARGA DE REGLAS
+# 1. CONFIGURACIÓN
 # ============================================================
 AMEX_FILE = "data/clean/normalized_amex.csv"
 VENDOR_LEDGER = "data/raw/appfolio/vendor_ledger-20260116.csv"
 RULES_FILE = "data/master/mapping_rules.xlsx"
 OUTPUT_FILE = "data/clean/amex_ras_net_of_appfolio.csv"
 
-DATE_WINDOW_DAYS = 2 
+DATE_WINDOW_DAYS = 2
 AMOUNT_TOLERANCE = 0.01
 
+# ============================================================
+# 2. CARGA DE REGLAS
+# ============================================================
 if os.path.exists(RULES_FILE):
     rules = pd.read_excel(RULES_FILE, sheet_name="Rules")
-    column_mapping = {
-        'Raw_Text (Key)': 'match_pattern',
-        'Mapped_Value': 'normalized_merchant',
-        'Category': 'vendor_class',
-        'GL_Account_Hint': 'gl_hint'
-    }
-    rules = rules.rename(columns=column_mapping)
-    # Filtro de seguridad: eliminamos cualquier fila donde el patrón sea nulo
+    rules = rules.rename(columns={
+        "Raw_Text (Key)": "match_pattern",
+        "Mapped_Value": "normalized_merchant",
+        "Category": "vendor_class",
+        "GL_Account_Hint": "gl_hint",
+    })
     rules = rules.dropna(subset=["match_pattern"])
-    
-    if 'priority' not in rules.columns:
-        rules['priority'] = 10 
-        
+    if "priority" not in rules.columns:
+        rules["priority"] = 10
     rules = rules.sort_values("priority", ascending=False)
-    # Aseguramos que todos los patrones sean strings
     rules["match_pattern"] = rules["match_pattern"].astype(str).str.lower()
-    print("✅ Reglas cargadas correctamente.")
+    print("Reglas cargadas correctamente.")
 else:
     rules = None
 
+
 def apply_mapping_rules(merchant_raw, rules_df):
-    if rules_df is None: 
-        return pd.Series({"vendor": str(merchant_raw).upper(), "class": "UNCLASSIFIED", "gl_hint": ""})
-    
+    if rules_df is None:
+        return pd.Series({
+            "vendor": str(merchant_raw).upper(),
+            "class": "UNCLASSIFIED",
+            "gl_hint": ""
+        })
+
     m = str(merchant_raw).lower()
     for _, r in rules_df.iterrows():
-        pattern = str(r["match_pattern"]) # Garantizamos que el patrón sea string
-        if not pattern or pattern == 'nan': continue
-        
-        # FIX: Usamos re.escape si no quieres regex o aseguramos que el valor sea válido
+        pattern = str(r["match_pattern"])
+        if not pattern or pattern == "nan":
+            continue
         try:
             if pd.Series(m).str.contains(pattern, regex=True, na=False).iloc[0]:
                 return pd.Series({
-                    "vendor": r["normalized_merchant"], 
+                    "vendor": r["normalized_merchant"],
                     "class": r["vendor_class"],
                     "gl_hint": r.get("gl_hint", "")
                 })
         except Exception:
             continue
-            
-    return pd.Series({"vendor": str(merchant_raw).upper(), "class": "UNCLASSIFIED", "gl_hint": ""})
+
+    return pd.Series({
+        "vendor": str(merchant_raw).upper(),
+        "class": "UNCLASSIFIED",
+        "gl_hint": ""
+    })
+
 
 # ============================================================
-# 2. PROCESAMIENTO DE DATOS
+# 3. CARGA DE DATOS
 # ============================================================
 amex = pd.read_csv(AMEX_FILE, parse_dates=["date"])
 ledger = pd.read_csv(VENDOR_LEDGER)
 
 print("🔍 Aplicando mapeo y clasificación...")
-amex_mapped = amex["merchant"].apply(lambda x: apply_mapping_rules(x, rules))
-amex = pd.concat([amex, amex_mapped], axis=1)
-
-def clean_currency(series):
-    return pd.to_numeric(series.astype(str).replace(r"[^\d\.-]", "", regex=True), errors="coerce").fillna(0.0).round(2)
+amex = pd.concat(
+    [amex, amex["merchant"].apply(lambda x: apply_mapping_rules(x, rules))],
+    axis=1
+)
 
 ledger.columns = ledger.columns.str.strip().str.lower()
-amt_col = 'amount' if 'amount' in ledger.columns else 'unpaid'
-ledger["amount_clean"] = clean_currency(ledger[amt_col])
-ledger["bill_date_clean"] = pd.to_datetime(ledger["bill date"], errors="coerce")
-ledger["desc_clean"] = ledger["description"].astype(str).str.upper()
+
+
+def safe_clean_currency(df, col):
+    if col not in df.columns:
+        return pd.Series(0.0, index=df.index)
+    return (
+        pd.to_numeric(
+            df[col].astype(str).replace(r"[^\d\.-]", "", regex=True),
+            errors="coerce"
+        )
+        .fillna(0.0)
+        .round(2)
+    )
+
+
+ledger["bill_date_clean"] = pd.to_datetime(ledger.get("bill date"), errors="coerce")
+ledger["desc_clean"] = ledger.get("description", "").astype(str).str.upper()
+ledger["amount_clean"] = safe_clean_currency(ledger, "amount")
+ledger["unpaid_clean"] = safe_clean_currency(ledger, "unpaid")
+
+if "vendor" not in ledger.columns:
+    fallback = next(
+        (c for c in ["payee", "name", "vendor name"] if c in ledger.columns),
+        "description"
+    )
+    ledger["vendor"] = ledger[fallback]
+    print(f"⚠️ Columna vendor no encontrada, usando '{fallback}'")
+
 
 # ============================================================
-# 3. DEDUPLICACIÓN ACE
+# 4. FUNCIÓN CORE — LEDGER COMO FUENTE DE VERDAD
 # ============================================================
-ledger_ace = ledger[
-    (ledger["amount_clean"] > 0) & 
-    (ledger["desc_clean"].str.contains("ACE", na=False)) & 
-    (~ledger["desc_clean"].str.contains("AMEX PAYMENT", na=False))
-].copy()
-ledger_ace["matched"] = False
+def remove_amex_using_ledger_unpaid(
+    ledger_df: pd.DataFrame,
+    amex_df: pd.DataFrame,
+    vendor_key: str,
+):
+    """
+    Elimina cargos AMEX hasta consumir exactamente el saldo unpaid del Ledger.
+    Nunca elimina más de lo que el Ledger respalda.
+    """
 
-# Usamos la columna mapeada para filtrar Ace Hardware
-# ============================================================
-# 3. DEDUPLICACIÓN ACE (ROBUSTA)
-# ============================================================
+    ledger = ledger_df.copy()
+    amex = amex_df.copy()
 
-ace_mask = (
-    amex["vendor"].str.upper().isin([
-        "ACE HARDWARE",
-        "SYKES ACE HARDWARE"
-    ])
-)
+    vendor_mask = (
+        ledger["vendor"].astype(str).str.upper().str.contains(vendor_key, na=False)
+        | ledger["desc_clean"].str.contains(vendor_key, na=False)
+        | ledger.get("gl account", "")
+            .astype(str)
+            .str.contains("6435", na=False)
+    )
 
+    bills = ledger[vendor_mask & (ledger["unpaid_clean"] > 0)]
 
-print("\n🔎 DEBUG ACE DETECTION")
-print("Total filas AMEX:", len(amex))
-print("Filas ACE detectadas:", ace_mask.sum())
-print(
-    amex.loc[ace_mask, ["merchant", "vendor", "normalized_merchant"]]
-    .head(10)
-)
+    ledger_truth_total = bills["unpaid_clean"].sum()
 
-amex_ace = amex[ace_mask].copy()
-amex_non_ace = amex[~ace_mask].copy()
+    if ledger_truth_total <= 0:
+        print(f"⚠️ No se encontró deuda para {vendor_key}")
+        return set(), 0.0
 
-ledger_ace = ledger[
-    (ledger["amount_clean"] > 0) &
-    (
-        ledger["desc_clean"].str.contains("ACE", na=False) |
-        ledger["gl account"].astype(str).str.contains("6435", na=False)
-    ) &
-    (~ledger["desc_clean"].str.contains("AMEX PAYMENT", na=False))
-].copy()
+    amex_vendor = (
+        amex[amex["vendor"].str.upper().str.contains(vendor_key, na=False)]
+        .sort_values("date")
+    )
 
-ledger_ace["matched"] = False
+    to_remove = set()
+    remaining = ledger_truth_total
 
-matches = set()
-
-for i, a in amex_ace.iterrows():
-    fecha_min = a["date"] - timedelta(days=DATE_WINDOW_DAYS)
-    fecha_max = a["date"] + timedelta(days=DATE_WINDOW_DAYS)
-
-    potential = ledger_ace[
-        (~ledger_ace["matched"]) &
-        (ledger_ace["bill_date_clean"] >= fecha_min) &
-        (ledger_ace["bill_date_clean"] <= fecha_max)
-    ]
-
-    for l_idx, l in potential.iterrows():
-        if abs(a["amount"] - l["amount_clean"]) <= AMOUNT_TOLERANCE:
-            matches.add(i)
-            ledger_ace.loc[l_idx, "matched"] = True
+    for idx, row in amex_vendor.iterrows():
+        if remaining <= 0.009:
             break
 
+        if row["amount"] <= remaining + 0.01:
+            to_remove.add(idx)
+            remaining -= row["amount"]
+
+    return to_remove, ledger_truth_total
+
 
 # ============================================================
-# 4. EXPORTACIÓN
+# 5. DEDUPLICACIÓN ACE
 # ============================================================
-amex_ace["appfolio_duplicate"] = amex_ace.index.isin(matches)
-final_df = pd.concat([amex_non_ace, amex_ace[~amex_ace["appfolio_duplicate"]]]).sort_values(by="date")
+print("\n🔎 Ejecutando deduplicación ACE (Ledger-driven)...")
 
-removed_amt = amex_ace.loc[amex_ace["appfolio_duplicate"], "amount"].sum()
+to_remove, ledger_total = remove_amex_using_ledger_unpaid(
+    ledger_df=ledger,
+    amex_df=amex,
+    vendor_key="ACE"
+)
+
+if "appfolio_duplicate" not in amex.columns:
+    amex["appfolio_duplicate"] = False
+
+amex.loc[amex.index.isin(to_remove), "appfolio_duplicate"] = True
+
+print(f"Ledger ACE (fuente de verdad): ${ledger_total:,.2f}")
+print(f"AMEX eliminado: ${amex.loc[list(to_remove), 'amount'].sum():,.2f}")
+
+
+# ============================================================
+# 6. EXPORTACIÓN
+# ============================================================
+final_df = (
+    amex[~amex["appfolio_duplicate"]]
+    .sort_values("date")
+    .reset_index(drop=True)
+)
+
+removed_amt = amex.loc[amex["appfolio_duplicate"], "amount"].sum()
 
 print("\n" + "═" * 55)
 print(f"║ {'REPORTE FINAL: AMEX vs APPFOLIO (ACE)':^51} ║")
 print("═" * 55)
-print(f"║ {'Monto Ace detectado en Amex:':<35} ${amex_ace['amount'].sum():>11,.2f} ║")
+print(f"║ {'Monto ACE detectado en AMEX:':<35} ${amex[amex['vendor'].str.contains('ACE', na=False)]['amount'].sum():>11,.2f} ║")
 print(f"║ {'Monto duplicado en AppFolio:':<35} ${removed_amt:>11,.2f} ║")
 print("╟" + "─" * 53 + "╢")
 print(f"║ {'VALOR NETO A CONTABILIZAR:':<35} ${final_df['amount'].sum():>11,.2f} ║")
 print("╚" + "═" * 53 + "╝")
 
 final_df.to_csv(OUTPUT_FILE, index=False, encoding="utf-8-sig")
-print(f"✅ Archivo generado: {OUTPUT_FILE}")
+print(f"Archivo generado: {OUTPUT_FILE}")


### PR DESCRIPTION
Pull Request Description
This PR introduces a Python/Pandas script that automates the deduplication of AMEX charges using the AppFolio Vendor Ledger as the single source of truth.
 Key Changes
- Data loading and normalization:
- Reads AMEX (normalized_amex.csv) and Vendor Ledger (vendor_ledger-YYYYMMDD.csv) files.
- Cleans key columns (amount, unpaid, bill date, description) for consistency.
- Incorporates mapping rules from mapping_rules.xlsx with priority support.
- Core function remove_amex_using_ledger_unpaid:
- Identifies invoices in the Vendor Ledger with outstanding balances.
- Removes AMEX charges until the unpaid balance recorded in the Ledger is fully consumed.
- Ensures no more charges are removed than what the Ledger supports.
- Deduplication process for ACE:
- Detects duplicates between AMEX and AppFolio.
- Marks duplicate transactions with the appfolio_duplicate column.
- Calculates and reports the total amount backed by the Ledger vs. the amount removed from AMEX.
- Result export:
- Generates a clean file (amex_ras_net_of_appfolio.csv) with net transactions to be accounted for.
- Provides a final console report with breakdowns of detected, removed, and net amounts.
Purpose
Prevent duplicate AMEX charges from being recorded when they are already reflected in the Vendor Ledger, ensuring the Ledger remains the single source of truth for outstanding balances.
Benefits
- Increased reliability in AMEX vs. AppFolio reconciliation.
- Reduced errors from duplicate invoices.
- Transparent and auditable workflow with clear reporting
